### PR TITLE
updated the repo links to be correct

### DIFF
--- a/cydia/index.html
+++ b/cydia/index.html
@@ -51,7 +51,7 @@
             <a
               class="add-to"
               id="add-to-cydia"
-              href="cydia://url/https://cydia.saurik.com/api/share#?source=https%3A%2F%2Fhaoict.github.io%2Fcydia"
+              href="cydia://url/https://cydia.saurik.com/api/share#?source=https://haoict.github.io/cydia/"
               role="button"
             >
               <div>
@@ -64,7 +64,7 @@
             <a
               class="add-to"
               id="add-to-zebra"
-              href="zbra://sources/add/https://cydia.ichitaso.com/"
+              href="zbra://sources/add/https://haoict.github.io/cydia/"
               role="button"
             >
               <div>
@@ -77,7 +77,7 @@
             <a
               class="add-to"
               id="add-to-sileo"
-              href="sileo://source/https://cydia.ichitaso.com/"
+              href="sileo://source/https://haoict.github.io/cydia/"
               role="button"
             >
               <div>


### PR DESCRIPTION
The links at the top were for a different repo. They now link to the correct URL.